### PR TITLE
feat : 클립보드 이미지 크롤링 API 구현

### DIFF
--- a/clipboard/admin.py
+++ b/clipboard/admin.py
@@ -1,0 +1,6 @@
+from django.contrib import admin
+from .models import Clipboard, Image
+
+# Register your models here.
+admin.site.register(Clipboard)
+admin.site.register(Image)

--- a/clipboard/apps.py
+++ b/clipboard/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class ClipboardConfig(AppConfig):
+    default_auto_field = 'django.db.models.BigAutoField'
+    name = 'clipboard'

--- a/clipboard/models.py
+++ b/clipboard/models.py
@@ -2,7 +2,6 @@ from django.db import models
 
 
 class Clipboard(models.Model):
-    id = models.IntegerField(primary_key=True)
     user_id = models.IntegerField(blank=False, null=False)
     created_at = models.DateTimeField(auto_now_add=True, blank=False, null=False)
     updated_at = models.DateTimeField(null=True, blank=True, auto_now=True)

--- a/clipboard/models.py
+++ b/clipboard/models.py
@@ -1,0 +1,22 @@
+from django.db import models
+
+
+class Clipboard(models.Model):
+    id = models.IntegerField(primary_key=True)
+    user_id = models.IntegerField(blank=False, null=False)
+    created_at = models.DateTimeField(auto_now_add=True, blank=False, null=False)
+    updated_at = models.DateTimeField(null=True, blank=True, auto_now=True)
+    deleted_at = models.DateTimeField(default=None, null=True, blank=True)
+
+
+class Image(models.Model):
+    clipboard = models.ForeignKey(
+        Clipboard,
+        on_delete=models.CASCADE,
+        related_name='images'
+    )
+    img_url = models.URLField(max_length=2048, blank=False, null=False)
+    created_at = models.DateTimeField(auto_now_add=True, blank=False, null=False)
+    updated_at = models.DateTimeField(null=True, blank=True, auto_now=True)
+    deleted_at = models.DateTimeField(default=None, null=True, blank=True)
+    favorite = models.BooleanField(default=False)

--- a/clipboard/serializers.py
+++ b/clipboard/serializers.py
@@ -5,7 +5,6 @@ from .models import Clipboard, Image
 # POST_Request
 class PostClipboardRequestSerializer(serializers.Serializer):
     user_id = serializers.IntegerField()
-    clipboard_id = serializers.IntegerField()
     url = serializers.URLField(max_length=2048)
 
 

--- a/clipboard/serializers.py
+++ b/clipboard/serializers.py
@@ -1,0 +1,25 @@
+from rest_framework import serializers
+from .models import Clipboard, Image
+
+
+# POST_Request
+class PostClipboardRequestSerializer(serializers.Serializer):
+    user_id = serializers.IntegerField()
+    clipboard_id = serializers.IntegerField()
+    url = serializers.URLField(max_length=2048)
+
+
+# Response
+class ImagesInnerDictSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Image
+        fields = ['id', 'img_url', 'created_at', 'updated_at', 'deleted_at', 'favorite']
+
+
+class ClipboardResponseSerializer(serializers.ModelSerializer):
+    images_list = ImagesInnerDictSerializer(many=True, read_only=True, source='images')
+
+    class Meta:
+        model = Clipboard
+        fields = ['id', 'images_list']
+

--- a/clipboard/tests.py
+++ b/clipboard/tests.py
@@ -1,0 +1,3 @@
+from django.test import TestCase
+
+# Create your tests here.

--- a/clipboard/urls.py
+++ b/clipboard/urls.py
@@ -1,0 +1,6 @@
+from django.urls import path
+from .views import PostClipboardView
+
+urlpatterns = [
+    path('clipboard/', PostClipboardView.as_view(), name='clipboard')
+]

--- a/clipboard/views.py
+++ b/clipboard/views.py
@@ -1,0 +1,74 @@
+from rest_framework import permissions, status
+from rest_framework.response import Response
+from rest_framework.views import APIView
+from drf_yasg.utils import swagger_auto_schema
+import requests
+from bs4 import BeautifulSoup
+
+from clipboard.models import *
+from clipboard.serializers import (PostClipboardRequestSerializer,
+                                   ClipboardResponseSerializer)
+from rest_framework.generics import get_object_or_404
+from django.utils import timezone
+
+
+class PostClipboardView(APIView):
+    permission_classes = [permissions.AllowAny]
+
+    @swagger_auto_schema(
+        operation_description="클립보드 이미지 크롤링 API",
+        operation_summary="클립보드 이미지 크롤링",
+        tags=["Clipboard API"],
+        operation_id="clipboard_images_parsing",
+        request_body=PostClipboardRequestSerializer,
+        responses={200: ClipboardResponseSerializer()}
+    )
+    def post(self, request, *args, **kwargs):
+        serializer = PostClipboardRequestSerializer(data=request.data)
+
+        if serializer.is_valid():
+            user_id = serializer.validated_data['user_id']
+            clipboard_id = serializer.validated_data['clipboard_id']
+            req_url = serializer.validated_data['url']
+
+            # 이미지 크롤링 + 저장
+            try:
+                # url에서 HTML 크롤링 + 파싱
+                req = requests.get(req_url)
+                soup = BeautifulSoup(req.content, 'html.parser')
+                img_tags = soup.find_all('img', {'src': True})
+
+                # Clipboard 모델에 request 된 clipboard_id 없으면 새로 create
+                clipboard, created = Clipboard.objects.get_or_create(
+                    id=clipboard_id,
+                    user_id=user_id)
+
+                # 파싱된 이미지 저장
+                for img_tag in img_tags:
+                    img_url = img_tag.get('src')
+                    Image.objects.create(clipboard=clipboard, img_url=img_url)
+
+                # Soft-delete : 50개 이상이면 가장 오래된 데이터 삭제
+                max_items = 50
+                current_items = Image.objects.filter(
+                    clipboard_id=clipboard_id, deleted_at__isnull=True).count()
+
+                if current_items > max_items:
+                    oldest_items = Image.objects.filter(
+                        clipboard_id=clipboard_id,
+                        deleted_at__isnull=True
+                        ).order_by('created_at')[:current_items - max_items]
+
+                    # soft delete 진행
+                    for item in oldest_items:
+                        item.deleted_at = timezone.now()
+                        item.save()
+
+                # deleted_at이 null인 경우만 조회
+                images = clipboard.images.filter(deleted_at__isnull=True)
+                response_serializer = ClipboardResponseSerializer({'id': clipboard_id, 'images_list': images})
+
+                return Response(response_serializer.data, status=status.HTTP_201_CREATED)
+
+            except Exception as e:
+                return Response({'error': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)

--- a/django_back/requirements.txt
+++ b/django_back/requirements.txt
@@ -16,3 +16,8 @@ sqlparse==0.4.4
 typing_extensions==4.9.0
 uritemplate==4.1.1
 openai==1.6.1
+
+django-cors-headers==4.3.1
+beautifulsoup4==4.12.2
+requests==2.31.0
+

--- a/django_back/settings.py
+++ b/django_back/settings.py
@@ -15,7 +15,6 @@ import os
 import environ
 import pymysql
 
-
 pymysql.install_as_MySQLdb()
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
@@ -23,7 +22,6 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 
 env = environ.Env()
 env.read_env()
-
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/4.2/howto/deployment/checklist/
@@ -36,7 +34,6 @@ DEBUG = True
 
 ALLOWED_HOSTS = []
 
-
 # Application definition
 
 INSTALLED_APPS = [
@@ -48,6 +45,8 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
     'rest_framework',
     'drf_yasg',
+    'bookmark',
+    'clipboard',
 ]
 
 MIDDLEWARE = [
@@ -80,7 +79,6 @@ TEMPLATES = [
 
 WSGI_APPLICATION = 'django_back.wsgi.application'
 
-
 # Database
 # https://docs.djangoproject.com/en/4.2/ref/settings/#databases
 
@@ -94,7 +92,6 @@ DATABASES = {
         'PORT': '3306',
     }
 }
-
 
 # Password validation
 # https://docs.djangoproject.com/en/4.2/ref/settings/#auth-password-validators
@@ -114,13 +111,12 @@ AUTH_PASSWORD_VALIDATORS = [
     },
 ]
 
-
 # Internationalization
 # https://docs.djangoproject.com/en/4.2/topics/i18n/
 
-LANGUAGE_CODE = 'en-us'
+LANGUAGE_CODE = 'ko-kr'
 
-TIME_ZONE = 'UTC'
+TIME_ZONE = 'Asia/Seoul'
 
 USE_I18N = True
 

--- a/django_back/urls.py
+++ b/django_back/urls.py
@@ -15,7 +15,7 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.contrib import admin
-from django.urls import path
+from django.urls import path, include
 from rest_framework.permissions import AllowAny
 from drf_yasg.views import get_schema_view
 from drf_yasg import openapi
@@ -37,6 +37,8 @@ schema_view = get_schema_view(
 
 urlpatterns = [
     path('admin/', admin.site.urls),
+    path('api/v1/', include('bookmark.urls')),
+    path('api/v1/', include(('clipboard.urls', 'api'))),
     re_path(r'^swagger(?P<format>\.json|\.yaml)$', schema_view.without_ui(cache_timeout=0), name='schema-json'),
     re_path(r'^swagger/$', schema_view.with_ui('swagger', cache_timeout=0), name='schema-swagger-ui'),
     re_path(r'^redoc/$', schema_view.with_ui('redoc', cache_timeout=0), name='schema-redoc'),


### PR DESCRIPTION
1. 사용한 패키지(`requirements.txt`에 작성해뒀습니다)
	- beautifulsoup4==4.12.2
	- requests==2.31.0

2. request body의 url = URLField
	→ 테스트 시 https:// 또는 http:// 포함한 URL 입력해야 정상 동작

3. 이미지 URL 크롤링 후 저장 시, DB에 soft delete 되지 않은 URL이 50개를 초과할 경우 created_at이 오래된 순으로 soft delete 처리

4. response로 새로 크롤링된 이미지 URL과 기존에 삭제하지 않은 URL들 함께 반환
